### PR TITLE
[FEATURE] Append timestamp to not merged css and js

### DIFF
--- a/app/code/local/Aoe/JsCssTstamp/Model/Package.php
+++ b/app/code/local/Aoe/JsCssTstamp/Model/Package.php
@@ -307,7 +307,6 @@ class Aoe_JsCssTstamp_Model_Package extends Mage_Core_Model_Design_Package
         }
 
         if ($this->addTstampToAssets) {
-            Mage::log('Aoe_JsCssTsamp: ' . $uri);
             $matches = array();
             if (preg_match('/(.*)\.(gif|png|jpg)$/i', $uri, $matches)) {
                 $uri = $matches[1] . '.' . $this->getVersionKey() . '.' . $matches[2];
@@ -315,5 +314,41 @@ class Aoe_JsCssTstamp_Model_Package extends Mage_Core_Model_Design_Package
         }
 
         return $uri;
+    }
+
+    /**
+     * Get skin file url
+     *
+     * @param string $file
+     * @param array $params
+     * @return string
+     */
+    public function getSkinUrl($file = null, array $params = array())
+    {
+        Varien_Profiler::start(__METHOD__);
+        if (empty($params['_type'])) {
+            $params['_type'] = 'skin';
+        }
+        if (empty($params['_default'])) {
+            $params['_default'] = false;
+        }
+        $this->updateParamDefaults($params);
+        if (!empty($file)) {
+            $result = $this->_fallback($file, $params, array(
+                array(),
+                array('_theme' => $this->getFallbackTheme()),
+                array('_theme' => self::DEFAULT_THEME),
+            ));
+        }
+        $result = $this->getSkinBaseUrl($params) . (empty($file) ? '' : $file);
+        Varien_Profiler::stop(__METHOD__);
+
+        if ($this->addTstampToAssets) {
+            $matches = array();
+            if (preg_match('/(.*)\.(css|js)$/i', $result, $matches)) {
+                $result = $matches[1] . '.' . $this->getVersionKey() . '.' . $matches[2];
+            }
+        }
+        return $result;
     }
 }


### PR DESCRIPTION
Now js and css files will have timestamp appended even if they are not
bundled into one file.

This change also adds timestamp to files included directly in the template
e.g.

```
<script type="text/javascript"
    src="<?php echo $this->getSkinUrl('js/jquery.js'); ?>"></script>
```
