### PR TITLE
Add name of files that cuased merge to fail

### DIFF
--- a/app/code/community/Aoe/JsCssTstamp/Model/Package.php
+++ b/app/code/community/Aoe/JsCssTstamp/Model/Package.php
@@ -218,7 +218,7 @@ class Aoe_JsCssTstamp_Model_Package extends Aoe_DesignFallback_Model_Design_Pack
                  * Using the file system to store the file
                  */
                 if (!$coreHelper->mergeFiles($files, $path, false, array($this, 'beforeMerge' . ucfirst($type)), $type)) {
-                    Mage::throwException("Error while merging {$type} files to path: " . $relativePath);
+                    Mage::throwException("Error while merging {$type} files " . print_r($files, true) . " to path: " . $relativePath);
                 }
                 break;
             case Aoe_JsCssTstamp_Model_System_Config_Source_Storage::DATABASE:
@@ -231,7 +231,7 @@ class Aoe_JsCssTstamp_Model_Package extends Aoe_DesignFallback_Model_Design_Pack
                 $dbStorage = $this->getDbStorage();
                 if (!$dbStorage->fileExists($relativePath)) {
                     if (!$coreHelper->mergeFiles($files, $path, false, array($this, 'beforeMerge' . ucfirst($type)), $type)) {
-                        Mage::throwException("Error while merging {$type} files to path: " . $relativePath);
+                        Mage::throwException("Error while merging {$type} files " . print_r($files, true) . " to path: " . $relativePath);
                     }
                     $dbStorage->saveFile($relativePath);
                 }


### PR DESCRIPTION
Simply output the array of files that were attempting to merge, if an error happens.
This makes debugging the issue a lot easier ;)

Example output:

Error while merging css files Array
(
    [0] => /var/www/testing/zabadaclean.com/zb-262-email-signup/skin/frontend/base/default/css/styles-ie8.css
    [1] => /var/www/testing/zabadaclean.com/zb-262-email-signup/skin/frontend/base/default/css/madisonisland-ie8.css
)
 to path: css/u.0040781806b768881dc0c15f157f7556.1441691636.css
