### PR TITLE
Updated travis.yml as failed magento installs are causing the builds to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,31 @@
+language: php
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  #- 5.6
+  #- hhvm
+matrix:
+  allow_failures:
+    - php: 5.6
+    - php: hhvm
+env:
+  global:
+    - SKIP_CLEANUP=1
+  matrix:
+    - MAGENTO_VERSION=magento-mirror-1.9.2.2
+    - MAGENTO_VERSION=magento-mirror-1.9.2.1
+    - MAGENTO_VERSION=magento-mirror-1.9.2.0
+    - MAGENTO_VERSION=magento-mirror-1.9.1.0
+    - MAGENTO_VERSION=magento-mirror-1.9.0.1
+    - MAGENTO_VERSION=magento-mirror-1.8.1.0
+    - MAGENTO_VERSION=magento-mirror-1.8.0.0
+    - MAGENTO_VERSION=magento-mirror-1.7.0.2
+script:
+  - curl -sSL https://raw.githubusercontent.com/AOEpeople/MageTestStand/master/setup.sh | bash
+notifications:
+  email:
+    recipients:
+      - travis@fabrizio-branca.de
+    on_success: always
+    on_failure: always


### PR DESCRIPTION
Magento have dropped the urls from which Magerun used to download Magento as a result of this the builds are currently failing as Magento can't be installed when the test suite runs. 

Magerun have provided an updates in the latest version (1.97.9) to support Magento mirrors and
AOE MageTestStand has been updated already.

I have updated the travis.yml to pull the magento installs from the Magento mirrors which come with the latest version of Magerun and also included Magento versions > 1.9.1.0 to the tests.
