### PR TITLE
Added system configuration setting to take store id's into account when generating the filename hash

### DIFF
--- a/app/code/community/Aoe/JsCssTstamp/Model/Package.php
+++ b/app/code/community/Aoe/JsCssTstamp/Model/Package.php
@@ -20,6 +20,9 @@ class Aoe_JsCssTstamp_Model_Package extends Aoe_DesignFallback_Model_Design_Pack
     protected $addTstampToAssets;
     protected $addTstampToAssetsCss;
     protected $addTstampToAssetsJs;
+    protected $cssCreateHashFromFileContent;
+    protected $jsCreateHashFromFileContent;
+    protected $cssAddStoreIdToHash;
     protected $storeMinifiedCssFolder;
     protected $storeMinifiedJsFolder;
 
@@ -37,6 +40,7 @@ class Aoe_JsCssTstamp_Model_Package extends Aoe_DesignFallback_Model_Design_Pack
         $this->addTstampToAssetsJs = Mage::getStoreConfig('dev/js/addTstampToJsFiles');
         $this->cssCreateHashFromFileContent = Mage::getStoreConfig('dev/css/createHashFromFileContent');
         $this->jsCreateHashFromFileContent = Mage::getStoreConfig('dev/js/createHashFromFileContent');
+        $this->cssAddStoreIdToHash = Mage::getStoreConfig('dev/css/addStoreIdToHash');
         $this->storeMinifiedCssFolder = rtrim(Mage::getBaseDir(), DS) . DS . trim(Mage::getStoreConfig('dev/css/storeMinifiedCssFolder'), DS);
         $this->storeMinifiedJsFolder = rtrim(Mage::getBaseDir(), DS) . DS . trim(Mage::getStoreConfig('dev/js/storeMinifiedJsFolder'), DS);
 
@@ -207,6 +211,10 @@ class Aoe_JsCssTstamp_Model_Package extends Aoe_DesignFallback_Model_Design_Pack
             }
         } else {
             $hashContent = $files;
+        }
+
+        if ($this->cssAddStoreIdToHash) {
+            array_push($hashContent, $this->getStore()->getId());
         }
 
         $targetFilename = md5(implode(',', $hashContent)) . $versionKey . '.css';

--- a/app/code/community/Aoe/JsCssTstamp/etc/system.xml
+++ b/app/code/community/Aoe/JsCssTstamp/etc/system.xml
@@ -130,7 +130,7 @@
                         <createHashFromFileContent translate="label comment" module="aoejscsststamp">
                             <label>Create merged filename hash from file content</label>
                             <comment>
-                                <![CDATA[If set to Yes, It will create hash of file content instead of file name which is being used in merged filename. Ex. s.9c859d05114b173356af905f073e4d0f.1448397352.css]]></comment>
+                                <![CDATA[If set to Yes, it will create hash of file content instead of file name which is being used in merged filename. Ex. s.9c859d05114b173356af905f073e4d0f.1448397352.css]]></comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>150</sort_order>
@@ -138,6 +138,17 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </createHashFromFileContent>
+                        <addStoreIdToHash translate="label comment" module="aoejscsststamp">
+                            <label>Add store ID to merged filename hash</label>
+                            <comment>
+                                <![CDATA[If set to Yes, the merged filename hash will take different store view's into consideration. This might be helpful if you have a multi-store set-up with different base URL's.]]></comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>200</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </addStoreIdToHash>
                     </fields>
                 </css>
                 <log>


### PR DESCRIPTION
I had issues with cross-origin policy errors because the font files in the CSS were being referenced with the base URL of the store view that first generated the merged file. The second store view (with different base URL's) would then use the CSS generated for the other store view, obviously using the wrong URL for things like font files, images, and so on. 
