### PR TITLE
Fix error: Call to a member function isAdmin() on string

### DIFF
--- a/app/code/community/Aoe/JsCssTstamp/Model/Package.php
+++ b/app/code/community/Aoe/JsCssTstamp/Model/Package.php
@@ -352,6 +352,9 @@ class Aoe_JsCssTstamp_Model_Package extends Aoe_DesignFallback_Model_Design_Pack
     protected function getProtocolSpecificTargetFileName($targetFilename)
     {
         $store = $this->getStore();
+        if (is_numeric($store)) {
+            $store = Mage::app()->getStore($store);
+        }
         if ($store->isAdmin()) {
             $secure = $store->isAdminUrlSecure();
         } else {


### PR DESCRIPTION
When using a custom admin url it will give the error "Call to a member function isAdmin() on string". This fixes it.